### PR TITLE
fix crash on item removed

### DIFF
--- a/src/random_enchants.cpp
+++ b/src/random_enchants.cpp
@@ -6,7 +6,7 @@ void rollPossibleEnchant(Player* player, Item* item)
     if (!sConfigMgr->GetOption<bool>("RandomEnchants.Enable", true))
         return;
 
-    if (!item)
+    if (item->GetState() == ITEM_REMOVED)
         return;
 
     uint32 itemQuality = item->GetTemplate()->Quality;
@@ -14,7 +14,7 @@ void rollPossibleEnchant(Player* player, Item* item)
 
     /* eliminates enchanting anything that isn't a recognized quality */
     /* eliminates enchanting anything but weapons/armor */
-    if ((itemQuality > 5 || itemQuality < 1) || (itemClass != 2 && itemClass != 4))
+    if ((itemQuality > ITEM_QUALITY_LEGENDARY || itemQuality < ITEM_QUALITY_NORMAL) || (itemClass != ITEM_CLASS_WEAPON && itemClass != ITEM_CLASS_ARMOR))
         return;
 
     int slotRand[3] = { -1, -1, -1 };
@@ -63,10 +63,7 @@ void rollPossibleEnchant(Player* player, Item* item)
 }
 
 uint32 getRandEnchantment(Item* item)
-{
-    if (!item)
-        return 0;
-    
+{    
     uint32 itemClass = item->GetTemplate()->Class;
     uint32 itemQuality = item->GetTemplate()->Quality;
     std::string classQueryString = "";


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- check item state

## Issues Addressed:
- `junk-to-gold` removes the item on create
- therefore when it arrives in this module it's already removed and crashes the worldserver

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. install this module
2. install `junk-to-gold` (https://github.com/noisiver/mod-junk-to-gold)
4. kill something, no crash. before it would always crash on loot
