### PR TITLE
Actually fix crash when using `junk-to-gold` module

### DIFF
--- a/src/random_enchants.cpp
+++ b/src/random_enchants.cpp
@@ -6,7 +6,7 @@ void rollPossibleEnchant(Player* player, Item* item)
     if (!sConfigMgr->GetOption<bool>("RandomEnchants.Enable", true))
         return;
 
-    if (item->GetState() == ITEM_REMOVED)
+    if (!item || !item->IsInWorld())
         return;
 
     uint32 itemQuality = item->GetTemplate()->Quality;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

My last fix attempt didn't work but this one does. There is a problem when using this module and the `junk-to-gold` module. When picking up an item, the junk to gold module removes it from the world and the player but the item pickup function in this module still gets called. Then the module tries to retrieve the itemtemplate and crashes. These modules shouldn't interfere due to item quality for enchants, but they do.

## Changes Proposed:
- Before applying an enchant, check if the item is still in the world. This actually works unlike checking whether its state is set to item_removed, checking for nullptr (it's not), or anything else I've tried.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- closes `https://github.com/azerothcore/mod-random-enchants/issues/32`

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Here's an image where the two modules are shown working together:
at the top: item receives enchants. at the bottom: item automatically sold.
<img width="665" height="605" alt="image" src="https://github.com/user-attachments/assets/dc74e360-7c69-47d9-9e41-ca26618b865e" />


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- see image above
- I also played for the last 2 hours and saw both modules work several times.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. install `mod-random-enchants` and `mod-junk-to-gold`
2. kill mobs until a gray item drops and a non-gray weapon/armor (can set enchant chance to 100 to see)
3. it doesn't crash. without this fix it crashes
